### PR TITLE
Windows导入问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ aiohttp
 toml
 Pillow
 argon2-cffi
+aiojobs
+decorator


### PR DESCRIPTION
用Linux运行了一下完全没问题
但是Windows执行`pip install -r requirements.txt`之后没导入`decorator`和`aiojobs`
不确定是不是我这边的问题

顺便提一下 监控2000左右的房间竟然没占多少CPU和内存tql
印象中基于websocket的连接比纯TCP多耗相当多的内存...